### PR TITLE
chore: move dependencies to dev-dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-fetchers",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Component wrapper to automatically dispatch actions when needed",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -58,14 +58,14 @@
     "redux": "3.6.0",
     "ts-jest": "^19.0.0",
     "typescript": "2.1.6",
-    "webpack": "^2.2.1"
+    "webpack": "^2.2.1",
+    "awesome-typescript-loader": "^3.1.2",
+    "html-webpack-plugin": "^2.28.0"
   },
   "peerDependencies": {
     "react-redux": "*",
     "react": "*"
   },
   "dependencies": {
-    "awesome-typescript-loader": "^3.1.2",
-    "html-webpack-plugin": "^2.28.0"
   }
 }


### PR DESCRIPTION
Moves some dependencies which were accidentally in `dependencies` to `dev-dependencies`.